### PR TITLE
Removed named release from python package version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-VERSION = '0.22.2-maple.3'
+VERSION = '0.22.2'
 
 setup(
     name='bigcommerce',


### PR DESCRIPTION
No need to put named release (e.g. "-maple.3") in the version number.